### PR TITLE
wip: Try to save current Website IPFS Hash to FFS storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ HackFS team https://hack.ethglobal.co/hackfs/teams/recpspjxSRMexZJVg/recHa78c3ed
   * [X] Create and view multiple Filecoin Addresses and associate them with PowerGate token.
   * [X] Retrieve Pin (IPFS Hash where front-end deployed) from PinList using Express.js API endpoint that connects to Pinata (http://ethquad.herokuapp.com/api/getWebsiteIPFSHash)
   * [X] Display latest Pin (Website IPFS Hash) in front-end
-  * [ ] Modify the Slate's "Make a Storage Deal" code to deploy that latest Pin to Filecoin Testnet (not just Local)
+  * [ ] Modify the Slate's "Make a Storage Deal" code to deploy that latest Pin to Lotus Filecoin Testnet (not just Local)
+    * [ ] Pending resolution of issues:
+      * https://github.com/filecoin-project/slate/issues/71
+      * https://github.com/textileio/powergate/issues/521
+      * https://github.com/ltfschoen/ethquad/pull/7
 * [X] Frontend deployed to IPFS Address using Pinata SDK
   * [X] Request decentralised domain name from Unstoppable Domains (https://ethquad.crypto)
   * [X] Deployment script generate a new Pin and Unpins all previous (./scripts/pinataUploadIpfs.js)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ HackFS team https://hack.ethglobal.co/hackfs/teams/recpspjxSRMexZJVg/recHa78c3ed
   * [X] Request decentralised domain name from Unstoppable Domains (https://ethquad.crypto)
   * [X] Deployment script generate a new Pin and Unpins all previous (./scripts/pinataUploadIpfs.js)
   * [X] Preview using Official IPFS Gateway (i.e. https://ipfs.io/ipfs/<IPFS_HASH>) in development environment (`yarn dev:ipfs:preview`)
-  * [ ] Configure domain name to redirect to Heroku (where it further redirects to the IPFS hash)
-    * Pending assistance from Slack group #hfs-sponsor-unstoppable-team https://filecoinproject.slack.com/archives/C016UAP2N8Z/p1594788644226200
+  * [X] Configure domain name to redirect to Heroku (where it further redirects to the IPFS hash)
+    * Pending name server changes to propagate https://filecoinproject.slack.com/archives/C016UAP2N8Z/p1594877963245700
 * [ ] Backend Express.js API connection to Infura Eth 2.0 Endpoint (https://altona.infura.io)
 
 ### Optional

--- a/client/src/helpers/index.js
+++ b/client/src/helpers/index.js
@@ -1,0 +1,34 @@
+// Source: https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+function arrayBufferToString(buf) {
+  return String.fromCharCode.apply(null, new Uint8Array(buf));
+}
+
+function stringToArrayBuffer(str) {
+  var buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+  var bufView = new Uint8Array(buf);
+  for (var i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+
+function toByteArray(hexString) {
+  var result = [];
+  for (var i = 0; i < hexString.length; i += 2) {
+    result.push(parseInt(hexString.substr(i, 2), 16));
+  }
+  return result;
+}
+
+function toHexString(byteArray) {
+  return Array.prototype.map.call(byteArray, function(byte) {
+    return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+  }).join('');
+}
+
+export {
+  arrayBufferToString,
+  stringToArrayBuffer,
+  toByteArray,
+  toHexString,
+}

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ const { connectToPinata } = require('../helpers/connectToPinata');
 
 const app = express();
 const port = process.env.PORT || 5000;
+const isProd = process.env.NODE_ENV === 'production';
 
 const corsWhitelist = [
   'http://localhost:5000',
@@ -18,12 +19,15 @@ const corsOptions = {
   'allowedHeaders': ['Content-Type'],
   'exposedHeaders': ['Content-Type'],
   'origin': function (origin, callback) {
-    if (corsWhitelist.indexOf(origin) !== -1) {
+    // Do not want to block REST tools or server-to-server requests
+    // when running with `yarn dev` on localhost:3000
+    if (corsWhitelist.indexOf(origin) !== -1 || !origin) {
       callback(null, true)
     } else {
       callback(new Error('Not allowed by CORS'))
     }
   },
+  // "origin": "*",
   'methods': 'GET,HEAD'
 };
 
@@ -47,7 +51,7 @@ app.use((err, req, res, next) => {
 app.get('/api/getWebsiteIPFSHash', cors(corsOptions),
   // Middleware chain
   async (req, res, next) => {
-    console.log('/api/getWebsiteIPFSHash');
+    console.log('Received GET request at API endpoint /api/getWebsiteIPFSHash');
     console.log('Connecting to Pinata');
     pinata = await connectToPinata();
     if (pinata) {


### PR DESCRIPTION
I've tried to save the current Website IPFS Hash to FFS storage on local testnet.
To setup I follow these steps:
* https://github.com/ltfschoen/ethquad#install-dependencies
* https://github.com/ltfschoen/ethquad#connect-to-lotus-filecoin-and-ipfs
* https://github.com/ltfschoen/ethquad#preview-website-redirecting-to-deployed-to-ipfs
* When the webpage opens, wait for it to display two alerts in blue "Website IPFS Hash: Q...." and "Token: ...", and for a blue button to appear "Save Website IPFS Hash to Filecoin Storage"
* Click the button "Save Website IPFS Hash to Filecoin Storage", then open the browser console and view the error messages.

But I've encountered issues when using FFS as follows, and I've added those concerns as `FIXME`'s in this PR, as follows. I've attached screenshots of the outputs below:

* How to check if any cid's exist in FFS without having to use a try/catch block so it doesn't crash with error `Uncaught (in promise) Error: stored item not found` if no items exist?

* How to check if a specific cid exists in FFS without having to use a try/catch block so it doesn't crash with error if we try to remove it `Uncaught (in promise) Error: stored item not found` but when it doesn't exist? Note that if we try using `ffs.get(cid)` and it doesn't exist then it also crashes with that same error, so we need to use a try/catch block with that too.

* How to use FFS to check if a cid already exists before running `ffs.pushConfig(cid)` without it crashing when we call `ffs.get(cid)` but it doesn't exist (e.g. why not add a new FFS function `isCid`?). It appears to be necessary to do this, otherwise if you try to call `ffs.pushConfig(cid)` when the cid already exists, it crashes with error `cid may have already been pinned, consider using override flag` but where do we find out how to use the override flag?

* How do we detect when it's been successfully stored to FFS Storage? Do we just watch the job and watch for a specific job status and check the `dealErrorList` is empty? (see screenshot)

* Why cidData (e.g. `42650d43746dd706dd531ca7bc36dacb0c4c0cc7ab6d69d9019299aa71c1f70156d7`) does not match the cid value (e.g. the Website IPFS Address of `QmUNQ3Rt1wbdUxynvDbaywxMDMerbWnZAZKZqnHB9wFW15`) when using `ffs.get(cid)`?

<img width="1641" alt="Screenshot 2020-07-16 at 11 07 56 am" src="https://user-images.githubusercontent.com/6226175/87653834-64c57b00-c756-11ea-8eab-35b1ce49de99.png">

<img width="1118" alt="Screenshot 2020-07-16 at 11 09 03 am" src="https://user-images.githubusercontent.com/6226175/87653840-668f3e80-c756-11ea-942a-8f59d59d1795.png">



